### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,11 @@ RUN apk --no-cache update && \
     apk add --no-cache jpeg-dev && \
     apk add --no-cache build-base && \
     apk add --no-cache python3-dev && \
-    pip3 install --no-cache-dir requests && \
-    pip3 install --no-cache-dir flask && \
-    pip3 install --no-cache-dir PyYAML && \
-    pip3 install --no-cache-dir Pillow  && \
-    pip3 install --no-cache-dir olefile && \
+    pip3 install --no-cache-dir requests --break-system-packages && \
+    pip3 install --no-cache-dir flask --break-system-packages && \
+    pip3 install --no-cache-dir PyYAML --break-system-packages && \
+    pip3 install --no-cache-dir Pillow  --break-system-packages && \
+    pip3 install --no-cache-dir olefile --break-system-packages && \
     mkdir /opt/ycast && \
     apk del --no-cache python3-dev && \
     apk del --no-cache build-base && \
@@ -49,7 +49,7 @@ RUN apk --no-cache update && \
 #    curl -L https://codeload.github.com/MaartenSanders/YCast/tar.gz/$YC_VERSION \
     | tar xvzC /opt/ycast && \
     apk del --no-cache curl && \
-    pip3 uninstall --no-cache-dir -y setuptools && \
+    pip3 uninstall --no-cache-dir -y setuptools --break-system-packages && \
 #    pip3 uninstall --no-cache-dir -y pip && \
     find /usr/lib -name \*.pyc -exec rm -f {} \; && \
 #    find /usr/share/terminfo -type f -not -name xterm -exec rm -f {} \; && \


### PR DESCRIPTION
I get an error running:
docker build  https://github.com/MaartenSanders/ycast-docker.git

I need to add the option --break-system-packages to pip3 install lines in the Dockerfile to solve the problem.

Fix:

    pip3 install --no-cache-dir requests --break-system-packages && \
    pip3 install --no-cache-dir flask --break-system-packages && \
    pip3 install --no-cache-dir PyYAML --break-system-packages && \
    pip3 install --no-cache-dir Pillow  --break-system-packages && \
    pip3 install --no-cache-dir olefile --break-system-packages && \
...
    pip3 uninstall --no-cache-dir -y setuptools --break-system-packages && \

Error without fix:

10.40 Executing busybox-1.36.1-r15.trigger
10.41 OK: 359 MiB in 67 packages
12.52 error: externally-managed-environment
12.52 
12.52 × This environment is externally managed
12.52 ╰─> 
12.52     The system-wide python installation should be maintained using the system
12.52     package manager (apk) only.
12.52     
12.52     If the package in question is not packaged already (and hence installable via
12.52     "apk add py3-somepackage"), please consider installing it inside a virtual
12.52     environment, e.g.:
12.52     
12.52     python3 -m venv /path/to/venv
12.52     . /path/to/venv/bin/activate
12.52     pip install mypackage
12.52     
12.52     To exit the virtual environment, run:
12.52     
12.52     deactivate
12.52     
12.52     The virtual environment is not deleted, and can be re-entered by re-sourcing
12.52     the activate file.
12.52     
12.52     To automatically manage virtual environments, consider using pipx (from the
12.52     pipx package).
12.52 
12.52 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
12.52 hint: See PEP 668 for the detailed specification.
